### PR TITLE
feat: navigation between sections (resolves #78)

### DIFF
--- a/src/_includes/partials/components/pagination.njk
+++ b/src/_includes/partials/components/pagination.njk
@@ -3,12 +3,25 @@
         
         <nav class="pagination" aria-label="posts pagination">
             <ul role="list">
-            {%- if previous %}
-                <li><a href="{{ previous.url }}"><span aria-hidden="true">&larr;</span><span class="visually-hidden">previous</span></a></li>
-            {%- endif %}
-            
-            {%- if next %}
-                <li><a href="{{ next.url }}"><span class="visually-hidden">next</span><span aria-hidden="true">&rarr;</span></a></li>
-            {%- endif %}
+            {% if not previous %}
+                {% if category == 'doing' %}
+                        {% set previous = collections['planning'][0] %}
+                {% elif category == 'reflecting' %}
+                        {% set previous = collections['doing'][0] %}
+                {% endif %}
+            {% endif %}
+            {% if previous %}
+            <li><a href="{{ previous.url }}"><span aria-hidden="true">&larr;</span><span class="visually-hidden">previous</span></a></li>
+            {% endif %}
+            {% if not next %}
+                {% if category == 'planning' %}
+                        {% set next = collections['doing'][0] %}
+                {% elif category == 'doing' %}
+                        {% set next = collections['reflecting'][0] %}
+                {% endif %}
+            {% endif %}
+            {% if next %}
+            <li><a href="{{ next.url }}"><span class="visually-hidden">next</span><span aria-hidden="true">&rarr;</span></a></li>
+            {% endif %}
             </ul>
         </nav>


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Once the last item in planning has been reached the next pagination link will take a visitor to the first item in doing, and the same in reverse.

## Steps to test

1. Navigate through all items.

**Expected behaviour:** Pagination works across sections.

## Additional information

Not applicable.

## Related issues

Resolves #78.