### PR TITLE
feat: update pagination buttons based on design feedback

### DIFF
--- a/src/_includes/layouts/guide.njk
+++ b/src/_includes/layouts/guide.njk
@@ -4,10 +4,26 @@
 
 {% if category == "planning" %}
     {% set headerBg = "orange-75" %}
+    {% set paginationBase = "orange" %}
+    {% set paginationHoverBg = "65" %}
+    {% set paginationBoxShadow = "55" %}
+    {% set paginationActiveFocusBg = "45" %}
 {% elif category == "doing" %}
     {% set headerBg = "yellow-75" %}
+    {% set paginationBase = "yellow" %}
+    {% set paginationHoverBg = "55" %}
+    {% set paginationBoxShadow = "45" %}
+    {% set paginationActiveFocusBg = "35" %}
 {% elif category == "reflecting" %}
     {% set headerBg = "green-55" %}
+    {% set paginationBase = "green" %}
+    {% set paginationHoverBg = "45" %}
+    {% set paginationBoxShadow = "35" %}
+    {% set paginationActiveFocusBg = "25" %}
+{% else %}
+    {% set paginationHoverBg = "75" %}
+    {% set paginationBoxShadow = "45" %}
+    {% set paginationActiveFocusBg = "35" %}
 {% endif %}
 
 {% block pageHeader %}
@@ -28,6 +44,7 @@
         </div>
     </div>
     <div class="[ prose ]">
+        {% include 'partials/components/pagination.njk' %}
         {{ content | safe }}
         {% if exampleSection %}
         <div class="[ flow ] [ bg bg--cream-95 ] [ examples ]">

--- a/src/_includes/partials/components/pagination.njk
+++ b/src/_includes/partials/components/pagination.njk
@@ -1,27 +1,33 @@
         {% set previous = collections[category] | getPreviousCollectionItem(page) %}
         {% set next = collections[category] | getNextCollectionItem(page) %}
+        {% set previousIcon = "category" %}
+        {% set nextIcon = "category" %}
         
         <nav class="pagination" aria-label="posts pagination">
             <ul role="list">
             {% if not previous %}
                 {% if category == 'doing' %}
                         {% set previous = collections['planning'][0] %}
+                        {% set previousIcon = "section" %}
                 {% elif category == 'reflecting' %}
                         {% set previous = collections['doing'][0] %}
+                        {% set previousIcon = "section" %}
                 {% endif %}
             {% endif %}
             {% if previous %}
-            <li><a href="{{ previous.url }}"><span aria-hidden="true">&larr;</span><span class="visually-hidden">previous</span></a></li>
+            <li><a href="{{ previous.url }}"><span class="pagination-icon" aria-hidden="true">{% if previousIcon === "category" %}{% include "svg/previous.svg" %}{% else %}{% include "svg/previousSection.svg" %}{% endif %}</span><span class="visually-hidden">previous</span></a></li>
             {% endif %}
             {% if not next %}
                 {% if category == 'planning' %}
                         {% set next = collections['doing'][0] %}
+                        {% set nextIcon = "section" %}
                 {% elif category == 'doing' %}
                         {% set next = collections['reflecting'][0] %}
+                        {% set nextIcon = "section" %}
                 {% endif %}
             {% endif %}
             {% if next %}
-            <li><a href="{{ next.url }}"><span class="visually-hidden">next</span><span aria-hidden="true">&rarr;</span></a></li>
+            <li><a href="{{ next.url }}"><span class="visually-hidden">next</span><span class="pagination-icon" aria-hidden="true">{% if nextIcon === "category" %}{% include "svg/next.svg" %}{% else %}{% include "svg/nextSection.svg" %}{% endif %}</span></a></li>
             {% endif %}
             </ul>
         </nav>

--- a/src/_includes/partials/global/stylesheets.njk
+++ b/src/_includes/partials/global/stylesheets.njk
@@ -4,4 +4,11 @@
         {% if headerBg %}
         <style>:root { --page-color: var(--color-{{ headerBg }}); }</style>
         {% endif %}
+        {% if paginationBase %}
+        <style>:root { 
+                --pagination-hover-bg: var(--color-{{ paginationBase }}-{{ paginationHoverBg }});
+                --pagination-boxshadow: var(--color-{{ paginationBase }}-{{ paginationBoxShadow }});
+                --pagination-active-focus-bg: var(--color-{{ paginationBase }}-{{ paginationActiveFocusBg }});
+        }</style>
+        {% endif %}
         {% uioStyles %}

--- a/src/_includes/svg/next.svg
+++ b/src/_includes/svg/next.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="10" viewBox="0 0 20 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M15.25 1L19 4.75M19 4.75L15.25 8.5M19 4.75H1" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/_includes/svg/nextSection.svg
+++ b/src/_includes/svg/nextSection.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="23" viewBox="0 0 24 23" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M15.25 8L19 11.75M19 11.75L15.25 15.5M19 11.75H1" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M11 15L11 19.375C11 20.0712 11.2709 20.7389 11.7532 21.2312C12.2354 21.7234 12.8894 22 13.5714 22L20.4286 22C21.1106 22 21.7646 21.7234 22.2468 21.2312C22.7291 20.7389 23 20.0712 23 19.375L23 3.625C23 2.92881 22.7291 2.26113 22.2468 1.76885C21.7646 1.27656 21.1106 1 20.4286 1L13.5714 1C12.8894 1 12.2354 1.27656 11.7532 1.76884C11.2709 2.26113 11 2.92881 11 3.625L11 8" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/_includes/svg/previous.svg
+++ b/src/_includes/svg/previous.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="10" viewBox="0 0 20 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4.75 8.5L1 4.75M1 4.75L4.75 1M1 4.75H19" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/_includes/svg/previousSection.svg
+++ b/src/_includes/svg/previousSection.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="23" viewBox="0 0 24 23" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8.75 15.5L5 11.75M5 11.75L8.75 8M5 11.75H23" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M13 8V3.625C13 2.92881 12.7291 2.26113 12.2468 1.76884C11.7646 1.27656 11.1106 1 10.4286 1H3.57143C2.88944 1 2.23539 1.27656 1.75315 1.76884C1.27092 2.26113 1 2.92881 1 3.625V19.375C1 20.0712 1.27092 20.7389 1.75315 21.2312C2.23539 21.7234 2.88944 22 3.57143 22H10.4286C11.1106 22 11.7646 21.7234 12.2468 21.2312C12.7291 20.7389 13 20.0712 13 19.375V15" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/styles/components/_pagination.scss
+++ b/src/assets/styles/components/_pagination.scss
@@ -21,7 +21,7 @@
 
 .pagination a {
   align-items: center;
-  background-color: var(--color-red-85);
+  background-color: var(--page-color);
   block-size: var(--space-lg);
   border-radius: 50%;
   display: flex;
@@ -30,24 +30,28 @@
   padding: 0.5rem;
   text-decoration: none;
 
+  .pagination-icon {
+    display: flex;
+  }
+
   &:hover {
-    background-color: var(--color-red-75);
+    background-color: var(--pagination-hover-bg);
   }
 
   &:focus {
-    box-shadow: 0 0 0 var(--space-xxs) var(--color-red-45);
+    box-shadow: 0 0 0 var(--space-xxs) var(--pagination-boxshadow);
     outline: none;
   }
 
   &:active,
   &[aria-current="page"] {
-    background-color: var(--color-red-45);
-    box-shadow: 0 0 0 var(--space-xxs) var(--color-red-45);
+    background-color: var(--pagination-boxshadow);
+    box-shadow: 0 0 0 var(--space-xxs) var(--pagination-boxshadow);
     color: var(--color-white);
     text-decoration: none;
 
     &:focus {
-      box-shadow: 0 0 0 var(--space-xxs) var(--color-red-35);
+      box-shadow: 0 0 0 var(--space-xxs) var(--pagination-active-focus-bg);
     }
   }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

* [ ] This pull request has been linted by running `npm run lint` without errors
* [ ] This pull request has been tested by running `npm run start` and reviewing affected routes
* [ ] This pull request has been built by running `npm run build` without errors
* [ ] This isn't a duplicate of an existing pull request

## Description

As requested by @sepidehshahi and Dana:

- Add previous and next pagination buttons at the top of the pages as well
- Change the pagination button colour to be the same as the page's colour theme
- Change the icon of the pagination button when previous/next is to another section
